### PR TITLE
Error caused to not defining absolute path in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -14,7 +14,7 @@ app.use(express.static(path.join(__dirname, "view")));
 app.use(express.static(path.join(__dirname, "images")));
 
 app.get("/", (req, res, next) => {
-  res.sendFile("index.html");
+  res.sendFile("index.html", { root: __dirname });
 });
 
 const server = app.listen(PORT);


### PR DESCRIPTION
Updated the error caused to not defining proper absolute path to the file, which needed to be sent.